### PR TITLE
npm-commander: from callback-based to sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+*.iml
+*.sublime-workspace
+pnpm-debug.log
+npm-debug.log
+.DS_Store
+.idea
+.npmrc
+target
+npm-shrinkwrap.json
+yarn.lock

--- a/lib/VersionFetcher.js
+++ b/lib/VersionFetcher.js
@@ -9,7 +9,7 @@ module.exports = (commander, shell, randomDirGenerator, packageHandler) => {
 
   function shellExec(cmd, cb) {
     shell.exec(cmd, (code, stdout, stderr) => {
-      if (code != 0) {
+      if (code !== 0) {
         cb(stderr)
       } else {
         cb(undefined, stdout)
@@ -28,8 +28,6 @@ module.exports = (commander, shell, randomDirGenerator, packageHandler) => {
     return randomDir
   }
 
-  commander.exec = thenify(commander.exec);
-
   shellExec = thenify(shellExec);
 
   let createdDirs = [];
@@ -38,15 +36,17 @@ module.exports = (commander, shell, randomDirGenerator, packageHandler) => {
     fetch: (name, version) => {
       const randomDir = generateDirectory();
       shell.pushd(randomDir);
-      return commander.exec(`npm pack ${name}@${version}`)
-        .then((output) => shellExec(`tar -xf ${output.trim()}`))
+      return Promise.resolve()
+        .then(() => commander.exec(`npm pack ${name}@${version}`))
+        .then(output => shellExec(`tar -xf ${output.trim()}`))
         .then(() => `${randomDir}/package`)
     },
 
     cloneAndPack: (cwd) => {
       let randomDir = generateDirectory();
       shell.pushd(randomDir);
-      return commander.exec(`npm pack ${cwd}`)
+      return Promise.resolve()
+        .then(() => commander.exec(`npm pack ${cwd}`))
         .then(() => shellExec(`tar -xf *.tgz`))
         .then(()=>`${randomDir}/package`)
     },

--- a/lib/npm-commander.js
+++ b/lib/npm-commander.js
@@ -1,6 +1,6 @@
 'use strict';
-var shelljs = require('shelljs');
-var fs = require('fs');
+const shelljs = require('shelljs');
+const fs = require('fs');
 
 module.exports.setup = setup;
 
@@ -10,16 +10,12 @@ module.exports.writePackage = writePackage;
 module.exports.exec = (cmd, cb) => exec(cmd, {silent: false}, cb);
 module.exports.execSilent = (cmd, cb) => exec(cmd, {silent: true}, cb);
 
-function readPackage(cb) {
-  try {
-    cb(undefined, JSON.parse(shelljs.cat('./package.json')));
-  } catch (e) {
-    cb(e, undefined)
-  }
+function readPackage() {
+  return JSON.parse(fs.readFileSync('./package.json', {encoding: 'utf-8'}));
 }
 
-function writePackage(packageJson, cb) {
-  fs.writeFile('./package.json', JSON.stringify(packageJson), {encoding: 'utf-8'}, cb);
+function writePackage(packageJson) {
+  return fs.writeFileSync('./package.json', JSON.stringify(packageJson), {encoding: 'utf-8'});
 }
 
 function setup() {
@@ -32,7 +28,7 @@ function setup() {
   }
 }
 
-function exec(cmd, opts, cb) {
+function exec(cmd, opts) {
   let command;
   if (dotNvmrcPresent()) {
     console.log(`Running 'nvm exec ${cmd}'`);
@@ -42,13 +38,12 @@ function exec(cmd, opts, cb) {
     command = cmd;
   }
 
-  shelljs.exec(command, opts, (code, output) => {
-    if (code !== 0) {
-      cb(error(cmd, code, output), undefined);
-    } else {
-      cb(undefined, output)
-    }
-  });
+  const res = shelljs.exec(command, opts);
+  if (res.code !== 0) {
+    throw error(cmd, res.code, res.output);
+  } else {
+    return res.output;
+  }
 }
 
 function dotNvmrcPresent() {

--- a/test/module-spec.js
+++ b/test/module-spec.js
@@ -117,13 +117,16 @@ describe('package', function () {
 
     const getPackage = (packegeName, cb) => {
       tempDir = support.cloneDir();
-      commander.exec(`npm pack ${packegeName}`, function (err, output) {
+      try {
+        const output = commander.exec(`npm pack ${packegeName}`);
         support.tarExtract(output, () => {
           shelljs.cd('./package');
           packageJson = support.readPackageJson();
           cb();
         });
-      });
+      } catch (e) {
+        cb(e, undefined);
+      }
     };
 
     beforeEach(function (done) {

--- a/test/npm-commander-spec.js
+++ b/test/npm-commander-spec.js
@@ -34,24 +34,14 @@ describe('npm commander', function() {
       commander.setup();
     });
 
-    it('exec() should fail given an invalid command', done => {
-      commander.exec('npmzqwe install', (error, output) => {
-        expect(output).to.be.undefined;
-        expect(error).to.be.instanceof(Error);
-        expect(error.message).to.contain('not found');
-        done();
-      });
+    it('exec() should fail given an invalid command', () => {
+      expect(() => commander.exec('npmzqwe install')).to.throw('not found');
     });
 
-    it('exec() should run command via "nvm", print command execution output, return collected output', done => {
-      commander.exec('npm install', (error, output) => {
-        expect(error).to.be.undefined;
-
-        expect(stdout).to.contain('Running \'nvm exec npm install\'');
-        expect(output).to.contain('npm WARN');
-
-        done();
-      });
+    it('exec() should run command via "nvm", print command execution output, return collected output', () => {
+      const output = commander.exec('npm install');
+      expect(stdout).to.contain('Running \'nvm exec npm install\'');
+      expect(output).to.contain('npm WARN');
     });
   });
 
@@ -61,39 +51,25 @@ describe('npm commander', function() {
       tempDir = support.clone({folder: './test/apps/without-nvmrc'});
     });
 
-    it('exec() should fail given an invalid command', done => {
-      commander.exec('npmzqwe install', (error, output) => {
-        expect(output).to.be.undefined;
-        expect(error).to.be.instanceof(Error);
-        expect(error.message).to.contain('not found');
-        done();
-      });
+    it('exec() should fail given an invalid command', () => {
+      expect(() => commander.exec('npmzqwe install')).to.throw('not found');
     });
 
-    it('exec() should run command via "npm", print command execution output, return collected output', done => {
-      commander.exec('npm install', (error, output) => {
-        expect(error).to.be.undefined;
-
-        expect(stdout).to.contain('Running \'npm install\'');
-        expect(output).to.contain('npm WARN');
-
-        done();
-      });
+    it('exec() should run command via "nvm", print command execution output, return collected output', () => {
+      const output = commander.exec('npm install');
+      expect(stdout).to.contain('Running \'npm install\'');
+      expect(output).to.contain('npm WARN');
     });
   });
 
   describe('execSilent() should not print command output to stdout', () => {
 
-    beforeEach(() => {
-      tempDir = support.clone({folder: './test/apps/without-nvmrc'});
-    });
+    beforeEach(() => tempDir = support.clone({folder: './test/apps/without-nvmrc'}));
 
-    it('exec() should run command in silent mode', done => {
-      commander.execSilent('npm install', (error, output) => {
-        expect(stdout).to.not.contain('npm WARN');
-        expect(output).to.contain('npm WARN');
-        done();
-      });
+    it('exec() should run command in silent mode', () => {
+      const output = commander.exec('npm install');
+      expect(stdout).to.not.contain('npm WARN');
+      expect(output).to.contain('npm WARN');
     });
   });
 });

--- a/test/versionFetcher-spec.js
+++ b/test/versionFetcher-spec.js
@@ -5,7 +5,8 @@ var assert = require('chai').assert;
 var _ = require('lodash');
 var VersionFetcher = require('../lib/VersionFetcher');
 
-describe('VersionFetcher', () => {
+describe('VersionFetcher', function() {
+  this.timeout(10000);
   const packageVersion = '1.2.3';
   const packageName = 'moshe';
   const rootTempPath = '/tmp';
@@ -34,12 +35,12 @@ describe('VersionFetcher', () => {
     commands = [];
 
     commander = {
-      exec: (arg, cb) => {
+      exec: arg => {
         commands.push(arg);
         if (arg.indexOf('npm pack') > -1) {
-          cb(undefined, tarFileName);
+          return tarFileName;
         } else {
-          cb();
+          return undefined;
         }
       }
     };
@@ -158,9 +159,7 @@ describe('VersionFetcher', () => {
 
       beforeEach(() => {
         const givenNpmErr = {
-          exec: (arg, cb) => {
-            cb('error');
-          }
+          exec: () => { throw 'error' }
         };
 
         versionFetcher = VersionFetcher(givenNpmErr,
@@ -189,7 +188,7 @@ describe('VersionFetcher', () => {
 
       beforeEach(() => {
         let shellErr = shell;
-        shellErr.exec = (cmd, cb) => cb(1, '123', 'error');
+        shellErr.exec = () => {throw 'error'};
 
         versionFetcher = VersionFetcher(commander,
           shellErr,


### PR DESCRIPTION
This is first in a series - there is no reason for wnpm-ci to be callback-based - most of stuff is sync anyways.

@shahata - please take a look and merge

