### PR TITLE
Disabling npm cache when resolving latest published version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.idea
+wnpm-ci.iml
+npm-debug.log

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ exports.getRegistryPackageInfo = function getRegistryPackageInfo(packageName, cb
     var registry = packageJson.publishConfig && packageJson.publishConfig.registry;
     var registryOption = registry ? "--registry " + registry : "";
 
-    commander.execSilent("npm view " + registryOption + " --json " + packageName, function (err, output) {
+    commander.execSilent("npm view --cache-min=0 " + registryOption + " --json " + packageName, function (err, output) {
       if (err) {
         if (err.message.indexOf("npm ERR! code E404") >= 0) {
           cb(undefined, undefined);
@@ -27,7 +27,9 @@ exports.getRegistryPackageInfo = function getRegistryPackageInfo(packageName, cb
           cb(err);
         }
       } else {
-        cb(undefined, JSON.parse(output));
+        const result = JSON.parse(output);
+        console.log('Version resolved from registry:', result['dist-tags'].latest);
+        cb(undefined, result);
       }
     });
   });


### PR DESCRIPTION
When running on stateful agents job might fail as latest version resolution might be done from cache.