### PR TITLE
add --only-production -> shrinkwrap includes only production dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Replace the text between the *****
   that are the same as the ones at the time of the build
   * Note that since CI does this, it will not be committed to git
   * If you don't like this behavior, you can use `wnpm-release --no-shrinkwrap` instead
+  * If you want to only keep production dependencies in the packed package, use the `--only-production` flag.
 * If the registry in the `publishConfig` is not Wix's internal registry, 
   you can also do `wnpm-release --publish-to-wix-registry` to make `wnpm-release` publish it to the Wix registry
 * If you want to silent the logs from `npm pack`, pass `--pack-quietly`  

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 "use strict";
-var child_process = require('child_process');
 var versionCalc = require('./lib/version-calculations');
 var commander = require('./lib/npm-commander');
 var DirectoryDiff = require('./lib/DirectoryDiff');
@@ -159,8 +158,7 @@ exports.publishPackage = function publishPackage(options, cb) {
 };
 
 exports.shrinkwrapPackage = function (cb, options) {
-  options = options || {};
-  var command = options.shouldOnlyKeepProductionDependencies ? "npm shrinkwrap --production" : "npm shrinkwrap";
+  var command = options && options.shouldOnlyKeepProductionDependencies ? "npm shrinkwrap --production" : "npm shrinkwrap";
   commander.exec(command, function (err) {
     cb(err);
   });
@@ -219,7 +217,7 @@ exports.prepareForRelease = function (options, cb) {
               }
               else
                 continue1(cb);
-            }, options);
+            }, {shouldOnlyKeepProductionDependencies: options.shouldOnlyKeepProductionDependencies});
           }
           else
             continue1(cb);

--- a/index.js
+++ b/index.js
@@ -158,8 +158,10 @@ exports.publishPackage = function publishPackage(options, cb) {
   });
 };
 
-exports.shrinkwrapPackage = function (cb) {
-  commander.exec("npm shrinkwrap", function (err) {
+exports.shrinkwrapPackage = function (cb, options) {
+  options = options || {};
+  var command = options.shouldOnlyKeepProductionDependencies ? "npm shrinkwrap --production" : "npm shrinkwrap";
+  commander.exec(command, function (err) {
     cb(err);
   });
 };
@@ -217,7 +219,7 @@ exports.prepareForRelease = function (options, cb) {
               }
               else
                 continue1(cb);
-            });
+            }, options);
           }
           else
             continue1(cb);

--- a/scripts/wnpm-release.js
+++ b/scripts/wnpm-release.js
@@ -4,11 +4,18 @@
 var shouldShrinkWrap = process.argv.indexOf("--no-shrinkwrap") < 0;
 var shouldPublishToWixRegistry = process.argv.indexOf("--publish-to-wix-registry") >= 0;
 var shouldPackQuietly = process.argv.indexOf("--pack-quietly") >= 0;
+var shouldOnlyKeepProductionDependencies = process.argv.indexOf("--only-production") >= 0;
+
+if(!shouldShrinkWrap && shouldOnlyKeepProductionDependencies) {
+  console.log("--only-production is only supported with a shrinkwrap file.");
+  process.exit(1);
+}
 
 require('../index').prepareForRelease({
   shouldShrinkWrap: shouldShrinkWrap,
   shouldPublishToWixRegistry: shouldPublishToWixRegistry,
   shouldPackQuietly: shouldPackQuietly
+  shouldOnlyKeepProductionDependencies: shouldOnlyKeepProductionDependencies
 }, function(err) {
   if (err) {
     console.log(err);

--- a/scripts/wnpm-release.js
+++ b/scripts/wnpm-release.js
@@ -14,7 +14,7 @@ if(!shouldShrinkWrap && shouldOnlyKeepProductionDependencies) {
 require('../index').prepareForRelease({
   shouldShrinkWrap: shouldShrinkWrap,
   shouldPublishToWixRegistry: shouldPublishToWixRegistry,
-  shouldPackQuietly: shouldPackQuietly
+  shouldPackQuietly: shouldPackQuietly,
   shouldOnlyKeepProductionDependencies: shouldOnlyKeepProductionDependencies
 }, function(err) {
   if (err) {


### PR DESCRIPTION
In our node artifacts, we don't want to include the dev-dependencies in the final artifact.
therefore, we currently use `npm prune --production` in a prepack / preshrinkwrap hook.

with --only-production, wnpm-ci will perform the prune.