### PR TITLE
Use `curl` to download the package tarball instead of `npm pack`

### DIFF
--- a/lib/version-fetcher.js
+++ b/lib/version-fetcher.js
@@ -6,8 +6,12 @@ const packageHandler = require('./package-handler');
 module.exports = {
   fetch: (name, version) => {
     const cwd = tmp.dirSync({unsafeCleanup: true}).name;
-    const archiveName = execSync(`npm pack ${name}@${version} --quiet`, {cwd}).toString().trim();
-    execSync(`tar -xf ${archiveName}`, {cwd});
+    const tarballURL = execSync(`npm view ${name}@${version} dist.tarball`, {cwd}).toString().trim();
+    if (!tarballURL) {
+      throw new Error(`Failed to find the tarball for ${name}@${version}`);
+    }
+    execSync(`curl -O --silent ${tarballURL}`, {cwd});
+    execSync(`tar -xf *.tgz`, {cwd});
     return `${cwd}/package`;
   },
 


### PR DESCRIPTION
This PR addresses an issue happening on CI agents, where running `npm pack` against a remote package fails because of errors with the npm cache directory. This provides a workaround to download the tarball directly using `curl` instead of using `npm pack` and thus avoiding npm going through the cache directory.

(This doesn't address the core issue on CI agents that causes `npm pack` to fail)