### PR TITLE
Get versions from all registries and scope/unscoped

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function findPublishedVersionsOnAllRegistries(cwd) {
 
   const uniqueVersions = [...new Set(versions)];
 
-  // This is just to report violations
+  // This is just to report stats from all registries
   const currentPublishedVersion = versionCalculations.calculateCurrentPublished(pkg.version, uniqueVersions);
   console.log(`currentPublishedVersion`, currentPublishedVersion);
   packagesInfo.forEach(pkgInfo => {

--- a/index.js
+++ b/index.js
@@ -4,23 +4,6 @@ const {compare} = require('./lib/version-comparator');
 const packageHandler = require('./lib/package-handler');
 const versionCalculations = require('./lib/version-calculations');
 
-// function getRegistryPackageInfo(cwd) {
-//   try {
-//     return JSON.parse(execSync('npm view --cache-min=0 --json', {cwd, stdio: 'pipe'}));
-//   } catch (e) {
-//     if (e.message.indexOf('npm ERR! code E404') >= 0) {
-//       return undefined;
-//     } else {
-//       throw e;
-//     }
-//   }
-// }
-
-// function findPublishedVersions(cwd) {
-//   const result = getRegistryPackageInfo(cwd);
-//   return normalizeVersions(result && result.versions);
-// }
-
 function maybeGetPackageInfo(pkgName, registryUrl) {
   try {
     return JSON.parse(execSync(`npm view --registry=${registryUrl} --@wix:registry=${registryUrl} --cache-min=0 --json ${pkgName}`, {stdio: 'pipe'}));

--- a/index.js
+++ b/index.js
@@ -117,5 +117,4 @@ function prepareForRelease(options) {
 
 module.exports = {
   prepareForRelease,
-  findPublishedVersionsOnAllRegistries
 };

--- a/index.js
+++ b/index.js
@@ -17,13 +17,10 @@ function findPublishedVersionsOnAllRegistries(cwd) {
   const unscopedPackageName = pkg.name.replace('@wix/', '');
   const scopedPackageName = `@wix/${unscopedPackageName}`;
 
-  const npmjsRegistryUrl = 'https://registry.npmjs.org/';
-  const artifactoryRegistryUrl = 'https://npm.dev.wixpress.com/';
-
   const packagesInfo = [
-    maybeGetPackageInfo(unscopedPackageName, artifactoryRegistryUrl),
-    maybeGetPackageInfo(scopedPackageName, artifactoryRegistryUrl),
-    maybeGetPackageInfo(scopedPackageName, npmjsRegistryUrl),
+    maybeGetPackageInfo(unscopedPackageName, 'https://npm.dev.wixpress.com/'),
+    maybeGetPackageInfo(scopedPackageName, 'https://npm.dev.wixpress.com/'),
+    maybeGetPackageInfo(scopedPackageName, 'https://registry.npmjs.org/'),
   ].filter(pkgInfo => !!pkgInfo);
 
   const versions = packagesInfo.reduce((acc, pkgInfo) => {


### PR DESCRIPTION
This PR gets all versions from:
* npm scoped
* artifactory scoped
* artifactory unscoped

and merges them, that way we can find out the max version across all publications