### PR TITLE
Revert "Revert "Allow npm to include gitHead as a package metadata during release. (#26)""

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const {execSync} = require('child_process');
 const {compare} = require('./lib/version-comparator');
 const packageHandler = require('./lib/package-handler');
 const versionCalculations = require('./lib/version-calculations');
+const writeGitHead = require('./lib/write-git-head');
 
 function maybeGetPackageInfo(pkgName, registryUrl) {
   try {
@@ -85,6 +86,8 @@ function prepareForRelease(options) {
   if (pkg.private) {
     console.log('No release because package is private');
   } else {
+    writeGitHead(options.cwd);
+
     if (process.env.DANGEROUSLY_FORCE_PKG_VERSION && (!process.env.DANGEROUSLY_FORCE_PKG_NAME || process.env.DANGEROUSLY_FORCE_PKG_NAME === pkg.name)) {
       console.log(`Forcing package ${pkg.name} version ${process.env.DANGEROUSLY_FORCE_PKG_VERSION}`);
       writePackageVersion(process.env.DANGEROUSLY_FORCE_PKG_VERSION, options.cwd);

--- a/lib/write-git-head.js
+++ b/lib/write-git-head.js
@@ -1,0 +1,25 @@
+/* Module to create a .git/HEAD file with hash from BUILD_VCS_NUMBER variable
+  Npm will read this hash and add it as a `gitHead` field to published package.
+  Check out more: https://github.com/npm/read-package-json/blob/6bac747004d5bc334a9f37c3799a965954d16641/read-json.js#L338
+*/
+
+const fs = require('fs');
+const path = require('path');
+const mkdirp = require('mkdirp');
+
+const writeGitHead = dir => {
+  const commitSha = process.env.BUILD_VCS_NUMBER;
+  if (commitSha) {
+    // Check if HEAD already exists
+    const head = path.resolve(dir, '.git/HEAD');
+    if (fs.existsSync(head)) {
+      return null;
+    }
+    // If no, create new one and write a hash.
+    mkdirp.sync(path.dirname(head));
+    fs.writeFileSync(head, commitSha, {encoding: 'utf-8'});
+    return commitSha;
+  }
+};
+
+module.exports = writeGitHead;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mocha-env-reporter": "^4.0.0"
   },
   "dependencies": {
+    "mkdirp": "^0.5.1",
     "semver": "^5.2.0",
     "tmp": "0.0.33"
   }

--- a/test/write-git-head.js
+++ b/test/write-git-head.js
@@ -1,0 +1,63 @@
+"use script";
+
+const fs = require('fs');
+const tmp = require('tmp');
+const path = require('path');
+const mkdirp = require('mkdirp');
+const {expect} = require('chai');
+const process = require('process');
+const writeGitHead = require('../lib/write-git-head');
+
+describe('write-git-head', () => {
+  let dirName, pwd;
+  const commitSha = 'ebfbfb37c3feaae51b0210014e575fee1ba01f85';
+  const INITIAL_BUILD_VCS_NUMBER = process.env.BUILD_VCS_NUMBER;
+
+  beforeEach(() => {
+    dirName = tmp.dirSync({unsafeCleanup: true}).name;
+    pwd = process.cwd();
+    process.env.BUILD_VCS_NUMBER = commitSha;
+  });
+  afterEach(() => {
+    process.chdir(pwd);
+    process.env.BUILD_VCS_NUMBER = INITIAL_BUILD_VCS_NUMBER;
+  });
+
+  it('should create .git dir and write a git HEAD if BUILD_VCS_NUMBER exists', () => {
+    const headFile = path.join(dirName, '.git/HEAD');
+    writeGitHead(dirName);
+
+    expect(fs.existsSync(headFile));
+    expect(fs.readFileSync(headFile, 'utf-8')).to.be.equal(commitSha);
+  });
+
+  it('should write a git HEAD to .git if BUILD_VCS_NUMBER exists', () => {
+    const gitDirname = path.join(dirName, '.git');
+    const headFile = path.join(gitDirname, 'HEAD');
+    mkdirp.sync(gitDirname)
+    writeGitHead(dirName);
+
+    expect(fs.existsSync(headFile));
+    expect(fs.readFileSync(headFile, 'utf-8')).to.be.equal(commitSha);
+  });
+
+  it('should not write a git HEAD if .git/HEAD exists', () => {
+    const gitDirname = path.join(dirName, '.git');
+    const headFile = path.join(gitDirname, 'HEAD');
+    const existedSha = '1bfbkw47c3feaae5u3s2100oi2575fee1ba01f8w'
+    mkdirp.sync(gitDirname)
+    fs.writeFileSync(headFile, existedSha, {encoding: 'utf-8'});
+    writeGitHead(dirName);
+
+    expect(fs.existsSync(headFile));
+    expect(fs.readFileSync(headFile, 'utf-8')).to.be.equal(existedSha);
+  });
+
+  it('should not write a git HEAD if BUILD_VCS_NUMBER doesn\'t exist', () => {
+    const headFile = path.join(dirName, '.git/HEAD');
+    delete process.env.BUILD_VCS_NUMBER;
+    writeGitHead(dirName);
+
+    expect(fs.existsSync(headFile) === false);
+  });
+});


### PR DESCRIPTION
This reverts commit 5f8a68695157c08f25bacad727244fb462ce3f07 and adds `mkdirp` as a dependency.