### PR TITLE
check public unscoped packages on npmjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,11 +18,16 @@ function findPublishedVersionsOnAllRegistries(cwd) {
   const unscopedPackageName = pkg.name.replace('@wix/', '');
   const scopedPackageName = `@wix/${unscopedPackageName}`;
 
-  const packagesInfo = [
+  let packagesInfo = [
     maybeGetPackageInfo(unscopedPackageName, 'https://npm.dev.wixpress.com/'),
     maybeGetPackageInfo(scopedPackageName, 'https://npm.dev.wixpress.com/'),
     maybeGetPackageInfo(scopedPackageName, 'https://registry.npmjs.org/'),
-  ].filter(pkgInfo => !!pkgInfo);
+  ];
+  // if package is unscoped and public on npmjs
+  if (pkg.publishConfig && pkg.publishConfig.registry === 'https://registry.npmjs.org/' && pkg.name === unscopedPackageName) {
+    packageInfo.push(maybeGetPackageInfo(unscopedPackageName, 'https://registry.npmjs.org/'))
+  }
+  packageInfo = packageInfo.filter(pkgInfo => !!pkgInfo);
 
   const versions = packagesInfo.reduce((acc, pkgInfo) => {
     const pkgVersions = normalizeVersions(pkgInfo.versions);


### PR DESCRIPTION
Current behavior: 
Collect versions from:
- unscoped on artifactory
- scoped on artifactory
- scoped on npmjs
 
If the package is unscoped and published on npmjs as a public package we do not get its package info.
This PR adds the above check.

I opted not to have ONLY this check because the publish scripts change all the time so I thought this approach will be safer (i think?).