### PR TITLE
make package info async - breaking

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ async function findPublishedVersionsOnAllRegistries(cwd) {
     maybeGetPackageInfo(unscopedPackageName, 'https://npm.dev.wixpress.com/'),
     maybeGetPackageInfo(scopedPackageName, 'https://npm.dev.wixpress.com/'),
     maybeGetPackageInfo(scopedPackageName, 'https://registry.npmjs.org/'),
-    ...(pkg.publishConfig && pkg.publishConfig.registry === 'https://registry.npmjs.org/' && pkg.name === unscopedPackageName ? [maybeGetPackageInfo(unscopedPackageName, 'https://registry.npmjs.org/')] : []) //// if package is unscoped and public on npmjs
+    // if package is unscoped and public on npmjs
+    ...(pkg.publishConfig && pkg.publishConfig.registry === 'https://registry.npmjs.org/' && pkg.name === unscopedPackageName ? [maybeGetPackageInfo(unscopedPackageName, 'https://registry.npmjs.org/')] : [])
   ])).filter(pkgInfo => !!pkgInfo);
   
   const versions = packagesInfo.reduce((acc, pkgInfo) => {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const path = require('path');
-const {exec, execSync} = require('child_process');
+const execa = require('execa');
+const {execSync} = require('child_process');
 const {compare} = require('./lib/version-comparator');
 const packageHandler = require('./lib/package-handler');
 const versionCalculations = require('./lib/version-calculations');
@@ -7,10 +8,8 @@ const writeGitHead = require('./lib/write-git-head');
 
 async function maybeGetPackageInfo(pkgName, registryUrl) {
   try {
-    const res = await new Promise((resolve, reject) => exec(`npm view --registry=${registryUrl} --@wix:registry=${registryUrl} --cache-min=0 --json ${pkgName}`, {stdio: 'pipe'}, (error, stdout, stderr) => {
-      error ? reject() : resolve(stdout)})
-    );
-    return JSON.parse(res);
+    const {stdout} = await execa(`npm view --registry=${registryUrl} --@wix:registry=${registryUrl} --cache-min=0 --json ${pkgName}`, {stdio: 'pipe', shell: true});
+    return JSON.parse(stdout);
   } catch (e) {
     return null;
   }

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ async function findPublishedVersionsOnAllRegistries(cwd) {
   }, []);
 
   const uniqueVersions = [...new Set(versions)];
-  
+
   // This is just to report stats from all registries
   const currentPublishedVersion = versionCalculations.calculateCurrentPublished(pkg.version, uniqueVersions);
   console.log(`currentPublishedVersion`, currentPublishedVersion);

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const writeGitHead = require('./lib/write-git-head');
 
 async function maybeGetPackageInfo(pkgName, registryUrl) {
   try {
-    const {stdout} = await execa(`npm view --registry=${registryUrl} --@wix:registry=${registryUrl} --cache-min=0 --json ${pkgName}`, {stdio: 'pipe', shell: true});
+    const {stdout} = await execa(`npm view --registry=${registryUrl} --@wix:registry=${registryUrl} --cache-min=0 --json ${pkgName}`, {shell: true});
     return JSON.parse(stdout);
   } catch (e) {
     return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -166,14 +166,12 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wnpm-ci",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -64,6 +64,18 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -88,11 +100,35 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "execa": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-2.0.3.tgz",
+      "integrity": "sha512-iM124nlyGSrXmuyZF1EMe83ESY2chIYVyDRZKgmcDynid2Q2v/+GuE7gNMl6Sy9Niwf4MC0DDxagOxeMPjuLsw==",
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "get-stream": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^3.0.0",
+        "onetime": "^5.1.0",
+        "p-finally": "^2.0.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -105,6 +141,14 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "get-stream": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+      "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "glob": {
       "version": "7.1.2",
@@ -153,6 +197,26 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
+    },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -247,13 +311,40 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "npm-run-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+      "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+      "requires": {
+        "path-key": "^3.0.0"
+      },
+      "dependencies": {
+        "path-key": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg=="
+        }
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "requires": {
+        "mimic-fn": "^2.1.0"
       }
     },
     "os-tmpdir": {
@@ -261,11 +352,21 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "p-finally": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "pathval": {
       "version": "1.1.0",
@@ -273,10 +374,42 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
     },
     "supports-color": {
       "version": "5.4.0",
@@ -301,11 +434,18 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "xml": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mocha-env-reporter": "^4.0.0"
   },
   "dependencies": {
+    "execa": "^2.0.3",
     "mkdirp": "^0.5.1",
     "semver": "^5.2.0",
     "tmp": "0.0.33"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wnpm-ci",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "CI support scripts for npm packages",
   "main": "index.js",
   "publishConfig": {

--- a/scripts/wnpm-release.js
+++ b/scripts/wnpm-release.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 const shouldBumpMinor = process.argv.indexOf("--bump-minor") >= 0;
 
-require('../index').prepareForRelease({shouldBumpMinor: shouldBumpMinor});
+(async () => {
+    await require('../index').prepareForRelease({shouldBumpMinor: shouldBumpMinor});
+})()

--- a/test/wnpm-release.spec.js
+++ b/test/wnpm-release.spec.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const {expect} = require('chai');
-const {execSync, exec} = require('child_process');
+const {execSync} = require('child_process');
 const {prepareForRelease} = require('../index');
 const versionFetcher = require('../lib/version-fetcher');
 const packageHandler = require('../lib/package-handler');
@@ -75,7 +75,7 @@ describe('wnpm-release', () => {
 describe('wnpm-release cli', () => {
   it('should bump patch by default', async () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
-    await new Promise(res => exec(path.resolve(__dirname, '../scripts/wnpm-release.js'), {cwd}, res));
+    execSync(path.resolve(__dirname, '../scripts/wnpm-release.js'), {cwd});
 
     const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);
@@ -85,7 +85,7 @@ describe('wnpm-release cli', () => {
 
   it('should bump minor', async () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
-    await new Promise(res => exec(path.resolve(__dirname, '../scripts/wnpm-release.js --bump-minor'), {cwd}, res));
+    execSync(path.resolve(__dirname, '../scripts/wnpm-release.js --bump-minor'), {cwd});
     const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);
     expect(pkg.version).to.not.equal('6.2.0');

--- a/test/wnpm-release.spec.js
+++ b/test/wnpm-release.spec.js
@@ -73,7 +73,7 @@ describe('wnpm-release', () => {
 });
 
 describe('wnpm-release cli', () => {
-  it('should bump patch by default', async () => {
+  it('should bump patch by default', () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
     execSync(path.resolve(__dirname, '../scripts/wnpm-release.js'), {cwd});
 
@@ -83,7 +83,7 @@ describe('wnpm-release cli', () => {
     expect(pkg.version).to.contain('6.2.');
   });
 
-  it('should bump minor', async () => {
+  it('should bump minor', () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
     execSync(path.resolve(__dirname, '../scripts/wnpm-release.js --bump-minor'), {cwd});
     const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));

--- a/test/wnpm-release.spec.js
+++ b/test/wnpm-release.spec.js
@@ -1,25 +1,25 @@
 const fs = require('fs');
 const path = require('path');
 const {expect} = require('chai');
-const {execSync} = require('child_process');
+const {execSync, exec} = require('child_process');
 const {prepareForRelease} = require('../index');
 const versionFetcher = require('../lib/version-fetcher');
 const packageHandler = require('../lib/package-handler');
 
 describe('wnpm-release', () => {
-  it('should not release a new version if same tarball is published', () => {
-    const latest = execSync('npm view . dist-tags.latest').toString().trim();
+  it('should not release a new version if same tarball is published', async () => {
+    latest = execSync('npm view . dist-tags.latest').toString().trim();
     const cwd = versionFetcher.fetch('wnpm-ci', latest);
-    prepareForRelease({cwd});
+    await prepareForRelease({cwd});
 
     const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(true);
     expect(pkg.version).to.equal(latest);
   });
 
-  it('should bump patch by default', () => {
+  it('should bump patch by default', async () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
-    prepareForRelease({cwd});
+    await prepareForRelease({cwd});
 
     const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);
@@ -27,9 +27,9 @@ describe('wnpm-release', () => {
     expect(pkg.version).to.contain('6.2.');
   });
 
-  it('should bump minor', () => {
+  it('should bump minor', async () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
-    prepareForRelease({cwd, shouldBumpMinor: true});
+    await prepareForRelease({cwd, shouldBumpMinor: true});
 
     const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);
@@ -37,32 +37,32 @@ describe('wnpm-release', () => {
     expect(pkg.version).to.contain('6.3.');
   });
 
-  it('should not touch version if it was modifier manually', () => {
+  it('should not touch version if it was modifier manually', async () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
     execSync(`npm version --no-git-tag-version 6.5.0`, {cwd});
-    prepareForRelease({cwd, shouldBumpMinor: true});
+    await prepareForRelease({cwd, shouldBumpMinor: true});
 
     const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);
     expect(pkg.version).to.equal('6.5.0');
   });
 
-  it('should support initial publish of new package', () => {
+  it('should support initial publish of new package', async () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
     const json = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     packageHandler.writePackageJson(path.join(cwd, 'package.json'), {...json, name: 'wnpm-kukuriku'});
-    prepareForRelease({cwd, shouldBumpMinor: true});
+    await prepareForRelease({cwd, shouldBumpMinor: true});
 
     const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);
     expect(pkg.version).to.equal('6.2.0');
   });
 
-  it('should bump version if comparing to published version fails', () => {
+  it('should bump version if comparing to published version fails', async () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
     const originalFetch = versionFetcher.fetch;
     versionFetcher.fetch = () => { throw new Error("Failed!")};
-    prepareForRelease({cwd});
+    await prepareForRelease({cwd});
     versionFetcher.fetch = originalFetch;
 
     const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
@@ -73,9 +73,9 @@ describe('wnpm-release', () => {
 });
 
 describe('wnpm-release cli', () => {
-  it('should bump patch by default', () => {
+  it('should bump patch by default', async () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
-    execSync(path.resolve(__dirname, '../scripts/wnpm-release.js'), {cwd});
+    await new Promise(res => exec(path.resolve(__dirname, '../scripts/wnpm-release.js'), {cwd}, res));
 
     const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);
@@ -83,10 +83,9 @@ describe('wnpm-release cli', () => {
     expect(pkg.version).to.contain('6.2.');
   });
 
-  it('should bump minor', () => {
+  it('should bump minor', async () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
-    execSync(path.resolve(__dirname, '../scripts/wnpm-release.js --bump-minor'), {cwd});
-
+    await new Promise(res => exec(path.resolve(__dirname, '../scripts/wnpm-release.js --bump-minor'), {cwd}, res));
     const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);
     expect(pkg.version).to.not.equal('6.2.0');

--- a/test/wnpm-release.spec.js
+++ b/test/wnpm-release.spec.js
@@ -8,7 +8,7 @@ const packageHandler = require('../lib/package-handler');
 
 describe('wnpm-release', () => {
   it('should not release a new version if same tarball is published', async () => {
-    latest = execSync('npm view . dist-tags.latest').toString().trim();
+    const latest = execSync('npm view . dist-tags.latest').toString().trim();
     const cwd = versionFetcher.fetch('wnpm-ci', latest);
     await prepareForRelease({cwd});
 


### PR DESCRIPTION
This PR makes version check across different registries async. This is a breaking change for users who use the api directly.

The plan is to make this a major version + to update Yoshi to use this version.

Risks:
- Users of the api who uses '*' or 'latest'
- Users who uses old Yoshi / locked Yoshi version will not get new updates of `wnpm-ci`