### PR TITLE
Make Scripts Async

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ async function prepareForRelease(options) {
   if (pkg.private) {
     console.log('No release because package is private');
   } else {
-    writeGitHead(options.cwd);
+    await writeGitHead(options.cwd);
 
     if (process.env.DANGEROUSLY_FORCE_PKG_VERSION && (!process.env.DANGEROUSLY_FORCE_PKG_NAME || process.env.DANGEROUSLY_FORCE_PKG_NAME === pkg.name)) {
       console.log(`Forcing package ${pkg.name} version ${process.env.DANGEROUSLY_FORCE_PKG_VERSION}`);

--- a/lib/directory-diff.js
+++ b/lib/directory-diff.js
@@ -1,5 +1,5 @@
 const versionFetcher = require('./version-fetcher');
-const {execSync} = require('child_process');
+const execa = require('execa');
 
 function cleanShrinkwrap(json) {
   for (let key in json) {
@@ -12,11 +12,11 @@ function cleanShrinkwrap(json) {
   return json;
 }
 
-function compareDirectories(path1, path2) {
-  versionFetcher.copyVersion(path1, path2, 'package.json');
-  versionFetcher.copyVersion(path1, path2, 'npm-shrinkwrap.json', cleanShrinkwrap);
+async function compareDirectories(path1, path2) {
+  await versionFetcher.copyVersion(path1, path2, 'package.json');
+  await versionFetcher.copyVersion(path1, path2, 'npm-shrinkwrap.json', cleanShrinkwrap);
   try {
-    execSync(`diff -rq ${path1} ${path2} -x .npmignore`);
+    await execa(`diff -rq ${path1} ${path2} -x .npmignore`, {shell: true});
     return true;
   } catch (e) {
     return false;

--- a/lib/package-handler.js
+++ b/lib/package-handler.js
@@ -1,11 +1,11 @@
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 
 module.exports = {
-  writePackageJson: (pathToPackage, packageJson) => {
-    fs.writeFileSync(path.resolve(pathToPackage), JSON.stringify(packageJson, null, 2), {encoding: 'utf-8'});
+  writePackageJson: async (pathToPackage, packageJson) => {
+    await fs.writeFile(path.resolve(pathToPackage), JSON.stringify(packageJson, null, 2), {encoding: 'utf-8'});
   },
-  readPackageJson: (pathToPackage) => {
-    return JSON.parse(fs.readFileSync(path.resolve(pathToPackage)));
+  readPackageJson: async (pathToPackage) => {
+    return JSON.parse(await fs.readFile(path.resolve(pathToPackage)));
   }
 };

--- a/lib/version-comparator.js
+++ b/lib/version-comparator.js
@@ -4,10 +4,10 @@ const packageHandler = require('./package-handler');
 const {compareDirectories} = require('./directory-diff');
 
 module.exports = {
-  compare: (cwd, version) => {
+  compare: async (cwd, version) => {
     const currVersionPath = versionFetcher.cloneAndPack(cwd);
-    const {name} = packageHandler.readPackageJson(path.join(cwd, 'package.json'))
+    const {name} = await packageHandler.readPackageJson(path.join(cwd, 'package.json'))
     const remoteVersionPath = versionFetcher.fetch(name, version, cwd);
-    return compareDirectories(remoteVersionPath, currVersionPath);
+    return await compareDirectories(remoteVersionPath, currVersionPath);
   }
 };

--- a/lib/version-comparator.js
+++ b/lib/version-comparator.js
@@ -5,9 +5,9 @@ const {compareDirectories} = require('./directory-diff');
 
 module.exports = {
   compare: async (cwd, version) => {
-    const currVersionPath = versionFetcher.cloneAndPack(cwd);
+    const currVersionPath = await versionFetcher.cloneAndPack(cwd);
     const {name} = await packageHandler.readPackageJson(path.join(cwd, 'package.json'))
-    const remoteVersionPath = versionFetcher.fetch(name, version, cwd);
+    const remoteVersionPath = await versionFetcher.fetch(name, version, cwd);
     return await compareDirectories(remoteVersionPath, currVersionPath);
   }
 };

--- a/lib/version-fetcher.js
+++ b/lib/version-fetcher.js
@@ -1,31 +1,41 @@
-const fs = require('fs');
+const fs = require('fs-extra');
 const tmp = require('tmp');
 const path = require('path');
-const {execSync} = require('child_process');
+const execa = require('execa');
 const packageHandler = require('./package-handler');
 
-function copyNpmrc(dirName, cwd) {
+function tmpDirAsync(opts) {
+  return new Promise((res, rej) =>
+    tmp.dir(opts, (err, name) => err ? rej(err) : res(name)));
+}
+
+async function copyNpmrc(dirName, cwd) {
   if (dirName) {
     const npmrc = path.join(dirName, '.npmrc');
-    if (fs.existsSync(npmrc)) {
-      fs.copyFileSync(npmrc, path.join(cwd, '.npmrc'));
+    if (await fs.exists(npmrc)) {
+      await fs.copyFile(npmrc, path.join(cwd, '.npmrc'));
     }
   }
 }
 
 module.exports = {
-  fetch: (name, version, dirName) => {
-    const cwd = tmp.dirSync({unsafeCleanup: true}).name;
-    copyNpmrc(dirName, cwd);
-    const archiveName = execSync(`npm pack ${name}@${version} --quiet`, {cwd}).toString().trim();
-    execSync(`tar -xf ${archiveName}`, {cwd});
+  fetch: async (name, version, dirName) => {
+    const cwd = await tmpDirAsync({unsafeCleanup: true});
+
+    await copyNpmrc(dirName, cwd);
+
+    const archiveName = await execa(`npm pack ${name}@${version} --quiet`, {cwd, shell: true})
+      .then(p => p.stdout)
+      .then(stdout => stdout.trim())
+
+    await execa(`tar -xf ${archiveName}`, {cwd, shell: true});
     return `${cwd}/package`;
   },
 
-  cloneAndPack: (dirName) => {
-    const cwd = tmp.dirSync({unsafeCleanup: true}).name;
-    const archiveName = execSync(`npm pack ${dirName} --quiet`, {cwd}).toString();
-    execSync(`tar -xf *.tgz`, {cwd});
+  cloneAndPack: async (dirName) => {
+    const cwd = await tmpDirAsync({unsafeCleanup: true});
+    await execa(`npm pack ${dirName} --quiet`, {cwd, shell: true});
+    await execa(`tar -xf *.tgz`, {cwd, shell: true});
     return `${cwd}/package`;
   },
 

--- a/lib/version-fetcher.js
+++ b/lib/version-fetcher.js
@@ -1,13 +1,11 @@
 const fs = require('fs-extra');
 const tmp = require('tmp');
 const path = require('path');
+const util = require('util');
 const execa = require('execa');
 const packageHandler = require('./package-handler');
 
-function tmpDirAsync(opts) {
-  return new Promise((res, rej) =>
-    tmp.dir(opts, (err, name) => err ? rej(err) : res(name)));
-}
+const tmpDirAsync = util.promisify(tmp.dir)
 
 async function copyNpmrc(dirName, cwd) {
   if (dirName) {

--- a/lib/version-fetcher.js
+++ b/lib/version-fetcher.js
@@ -29,16 +29,16 @@ module.exports = {
     return `${cwd}/package`;
   },
 
-  copyVersion: (remotePath, localPath, name, transformer) => {
+  copyVersion: async (remotePath, localPath, name, transformer) => {
     transformer = transformer || (x => x);
     try {
       const localFile = path.join(localPath, name);
       const remoteFile = path.join(remotePath, name);
-      let currPackage = transformer(packageHandler.readPackageJson(localFile));
-      let remotePackage = transformer(packageHandler.readPackageJson(remoteFile));
+      let currPackage = transformer(await packageHandler.readPackageJson(localFile));
+      let remotePackage = transformer(await packageHandler.readPackageJson(remoteFile));
       currPackage.version = remotePackage.version;
-      packageHandler.writePackageJson(localFile, currPackage);
-      packageHandler.writePackageJson(remoteFile, remotePackage);
+      await packageHandler.writePackageJson(localFile, currPackage);
+      await packageHandler.writePackageJson(remoteFile, remotePackage);
     } catch (e) {
       //
     }

--- a/lib/write-git-head.js
+++ b/lib/write-git-head.js
@@ -3,21 +3,24 @@
   Check out more: https://github.com/npm/read-package-json/blob/6bac747004d5bc334a9f37c3799a965954d16641/read-json.js#L338
 */
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const mkdirp = require('mkdirp');
 
-const writeGitHead = dir => {
+const mkdirPPromise = (dir) =>
+  new Promise((res, rej) => mkdirp(dir, err => err ? rej(err) : res()));
+
+const writeGitHead = async dir => {
   const commitSha = process.env.BUILD_VCS_NUMBER;
   if (commitSha) {
     // Check if HEAD already exists
     const head = path.resolve(dir, '.git/HEAD');
-    if (fs.existsSync(head)) {
+    if (await fs.exists(head)) {
       return null;
     }
     // If no, create new one and write a hash.
-    mkdirp.sync(path.dirname(head));
-    fs.writeFileSync(head, commitSha, {encoding: 'utf-8'});
+    await mkdirPPromise(path.dirname(head));
+    await fs.writeFile(head, commitSha, {encoding: 'utf-8'});
     return commitSha;
   }
 };

--- a/lib/write-git-head.js
+++ b/lib/write-git-head.js
@@ -6,9 +6,9 @@
 const fs = require('fs-extra');
 const path = require('path');
 const mkdirp = require('mkdirp');
+const util = require('util');
 
-const mkdirPPromise = (dir) =>
-  new Promise((res, rej) => mkdirp(dir, err => err ? rej(err) : res()));
+const mkdirPPromise = util.promisify(mkdirp);
 
 const writeGitHead = async dir => {
   const commitSha = process.env.BUILD_VCS_NUMBER;

--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
   },
   "devDependencies": {
     "chai": "^4.0.0",
+    "chai-as-promised": "^7.1.1",
     "mocha": "^5.0.0",
     "mocha-env-reporter": "^4.0.0"
   },
   "dependencies": {
     "execa": "^2.0.3",
+    "fs-extra": "^8.1.0",
     "mkdirp": "^0.5.1",
     "semver": "^5.2.0",
     "tmp": "0.0.33"

--- a/test/directory-diff.spec.js
+++ b/test/directory-diff.spec.js
@@ -11,73 +11,73 @@ describe('directory-diff', () => {
     path2 = tmp.dirSync({unsafeCleanup: true}).name;
   });
 
-  it('should return true for identical dirs', () => {
+  it('should return true for identical dirs', async () => {
     fs.writeFileSync(path.join(path1, 'a'), '111');
     fs.writeFileSync(path.join(path2, 'a'), '111');
-    expect(compareDirectories(path1, path2)).to.equal(true);
+    expect(await compareDirectories(path1, path2)).to.equal(true);
   });
 
-  it('should return false for different dirs', () => {
+  it('should return false for different dirs', async () => {
     fs.writeFileSync(path.join(path1, 'a'), '111');
     fs.writeFileSync(path.join(path2, 'a'), '222');
-    expect(compareDirectories(path1, path2)).to.equal(false);
+    expect(await compareDirectories(path1, path2)).to.equal(false);
   });
 
-  it('should return true for deeply identical dirs', () => {
+  it('should return true for deeply identical dirs', async () => {
     fs.writeFileSync(path.join(path1, 'a'), '111');
     fs.writeFileSync(path.join(path2, 'a'), '111');
     fs.mkdirSync(path.join(path1, 'b'));
     fs.mkdirSync(path.join(path2, 'b'));
     fs.writeFileSync(path.join(path1, 'b', 'c'), '111');
     fs.writeFileSync(path.join(path2, 'b', 'c'), '111');
-    expect(compareDirectories(path1, path2)).to.equal(true);
+    expect(await compareDirectories(path1, path2)).to.equal(true);
   });
 
-  it('should return false deeply different dirs', () => {
+  it('should return false deeply different dirs', async () => {
     fs.writeFileSync(path.join(path1, 'a'), '111');
     fs.writeFileSync(path.join(path2, 'a'), '111');
     fs.mkdirSync(path.join(path1, 'b'));
     fs.mkdirSync(path.join(path2, 'b'));
     fs.writeFileSync(path.join(path1, 'b', 'c'), '111');
     fs.writeFileSync(path.join(path2, 'b', 'c'), '222');
-    expect(compareDirectories(path1, path2)).to.equal(false);
+    expect(await compareDirectories(path1, path2)).to.equal(false);
   });
 
-  it('should ignore .npmignore when comparing', () => {
+  it('should ignore .npmignore when comparing', async () => {
     fs.writeFileSync(path.join(path1, '.npmignore'), '111');
     fs.writeFileSync(path.join(path1, 'a'), '111');
     fs.writeFileSync(path.join(path2, 'a'), '111');
-    expect(compareDirectories(path1, path2)).to.equal(true);
+    expect(await compareDirectories(path1, path2)).to.equal(true);
   });
 
-  it('should return false for different dependencies in package.json', () => {
+  it('should return false for different dependencies in package.json', async () => {
     fs.writeFileSync(path.join(path1, 'package.json'), JSON.stringify({dependencies: {lodash: '1.0.0'}}));
     fs.writeFileSync(path.join(path2, 'package.json'), JSON.stringify({dependencies: {lodash: '2.0.0'}}));
-    expect(compareDirectories(path1, path2)).to.equal(false);
+    expect(await compareDirectories(path1, path2)).to.equal(false);
   });
 
-  it('should ignore version in package.json', () => {
+  it('should ignore version in package.json', async () => {
     fs.writeFileSync(path.join(path1, 'package.json'), JSON.stringify({version: '1.0.0'}));
     fs.writeFileSync(path.join(path2, 'package.json'), JSON.stringify({version: '2.0.0'}));
-    expect(compareDirectories(path1, path2)).to.equal(true);
+    expect(await compareDirectories(path1, path2)).to.equal(true);
   });
 
-  it('should return false for different dependencies in npm-shrinkwrap.json', () => {
+  it('should return false for different dependencies in npm-shrinkwrap.json', async () => {
     fs.writeFileSync(path.join(path1, 'npm-shrinkwrap.json'), JSON.stringify({dependencies: {lodash: {}}}));
     fs.writeFileSync(path.join(path2, 'npm-shrinkwrap.json'), JSON.stringify({dependencies: {underscore: {}}}));
-    expect(compareDirectories(path1, path2)).to.equal(false);
+    expect(await compareDirectories(path1, path2)).to.equal(false);
   });
 
-  it('should return false for different version in npm-shrinkwrap.json', () => {
+  it('should return false for different version in npm-shrinkwrap.json', async () => {
     fs.writeFileSync(path.join(path1, 'npm-shrinkwrap.json'), JSON.stringify({dependencies: {lodash: {version: '1.0.0'}}}));
     fs.writeFileSync(path.join(path2, 'npm-shrinkwrap.json'), JSON.stringify({dependencies: {lodash: {version: '2.0.0'}}}));
-    expect(compareDirectories(path1, path2)).to.equal(false);
+    expect(await compareDirectories(path1, path2)).to.equal(false);
   });
 
-  it('should ignore other strings in npm-shrinkwrap.json', () => {
+  it('should ignore other strings in npm-shrinkwrap.json', async () => {
     fs.writeFileSync(path.join(path1, 'npm-shrinkwrap.json'), JSON.stringify({dependencies: {lodash: {url: 'xxx'}}}));
     fs.writeFileSync(path.join(path2, 'npm-shrinkwrap.json'), JSON.stringify({dependencies: {lodash: {url: 'yyy'}}}));
-    expect(compareDirectories(path1, path2)).to.equal(true);
+    expect(await compareDirectories(path1, path2)).to.equal(true);
   });
 
 });

--- a/test/package-handler.spec.js
+++ b/test/package-handler.spec.js
@@ -15,28 +15,28 @@ describe('package-handler', () => {
   });
   afterEach(() => process.chdir(pwd));
 
-  it('should read a package from path', () => {
+  it('should read a package from path', async () => {
     const fileName = path.join(dirName, 'package.json');
     const obj = {version: 123};
     fs.writeFileSync(fileName, JSON.stringify(obj));
-    expect(packageHandler.readPackageJson(fileName)).to.eql(obj);
+    expect(await packageHandler.readPackageJson(fileName)).to.eql(obj);
   });
 
-  it('should write a package to path', () => {
+  it('should write a package to path', async () => {
     const fileName = path.join(dirName, 'package.json');
-    packageHandler.writePackageJson(fileName, {});
+    await packageHandler.writePackageJson(fileName, {});
     expect(fs.readFileSync(fileName).toString()).to.be.equal(JSON.stringify({}));
   });
 
-  it('should read a package from relative path', () => {
+  it('should read a package from relative path', async () => {
     const obj = {version: 123};
     fs.writeFileSync(path.join(dirName, 'package.json'), JSON.stringify(obj));
     process.chdir(dirName);
-    expect(packageHandler.readPackageJson('package.json')).to.eql(obj);
+    expect(await packageHandler.readPackageJson('package.json')).to.eql(obj);
   });
 
-  it('should write a package to relative path', () => {
-    packageHandler.writePackageJson(path.join(dirName, 'package.json'), {});
+  it('should write a package to relative path', async () => {
+    await packageHandler.writePackageJson(path.join(dirName, 'package.json'), {});
     process.chdir(dirName);
     expect(fs.readFileSync('package.json').toString()).to.be.equal(JSON.stringify({}));
   });

--- a/test/version-comparator.spec.js
+++ b/test/version-comparator.spec.js
@@ -5,14 +5,14 @@ const {compare} = require('../lib/version-comparator');
 const versionFetcher = require('../lib/version-fetcher');
 
 describe('version-comparator', () => {
-  it('should compare version with itself', () => {
+  it('should compare version with itself', async () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
-    expect(compare(cwd, '6.2.0')).to.equal(true);
+    expect(await compare(cwd, '6.2.0')).to.equal(true);
   });
 
-  it('should return false if we have difference', () => {
+  it('should return false if we have difference', async () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
     fs.writeFileSync(path.join(cwd, 'abc'), '111')
-    expect(compare(cwd, '6.2.0')).to.equal(false);
+    expect(await compare(cwd, '6.2.0')).to.equal(false);
   });
 });

--- a/test/version-comparator.spec.js
+++ b/test/version-comparator.spec.js
@@ -6,12 +6,12 @@ const versionFetcher = require('../lib/version-fetcher');
 
 describe('version-comparator', () => {
   it('should compare version with itself', async () => {
-    const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
+    const cwd = await versionFetcher.fetch('wnpm-ci', '6.2.0');
     expect(await compare(cwd, '6.2.0')).to.equal(true);
   });
 
   it('should return false if we have difference', async () => {
-    const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
+    const cwd = await versionFetcher.fetch('wnpm-ci', '6.2.0');
     fs.writeFileSync(path.join(cwd, 'abc'), '111')
     expect(await compare(cwd, '6.2.0')).to.equal(false);
   });

--- a/test/version-fetcher.spec.js
+++ b/test/version-fetcher.spec.js
@@ -1,27 +1,30 @@
 const tmp = require('tmp');
 const path = require('path');
-const {expect} = require('chai');
+const {expect, use} = require('chai');
+const chaiAsPromised = require('chai-as-promised');
 const versionFetcher = require('../lib/version-fetcher');
 const packageHandler = require('../lib/package-handler');
 
+use(chaiAsPromised);
+
 describe('version-fetcher', () => {
-  it('should retrieve the version from npm and pack it', () => {
+  it('should retrieve the version from npm and pack it', async () => {
     const dirName = versionFetcher.fetch('wnpm-ci', '6.2.0');
-    const pkg = packageHandler.readPackageJson(path.join(dirName, 'package.json'));
+    const pkg = await packageHandler.readPackageJson(path.join(dirName, 'package.json'));
     expect(pkg.name).to.equal('wnpm-ci');
     expect(pkg.version).to.equal('6.2.0');
   });
 
-  it('should pack current package', () => {
+  it('should pack current package', async () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
     const dirName = versionFetcher.cloneAndPack(cwd);
-    const pkg = packageHandler.readPackageJson(path.join(dirName, 'package.json'));
+    const pkg = await packageHandler.readPackageJson(path.join(dirName, 'package.json'));
     expect(pkg.name).to.equal('wnpm-ci');
     expect(pkg.version).to.equal('6.2.0');
     expect(dirName).to.not.equal(cwd);
   });
 
-  it('should copy the version from one package to another', () => {
+  it('should copy the version from one package to another', async () => {
     const remotePath = tmp.dirSync({unsafeCleanup: true}).name;
     const localPath = tmp.dirSync({unsafeCleanup: true}).name;
     const remoteFile = path.join(remotePath, 'kaki.json');
@@ -29,17 +32,21 @@ describe('version-fetcher', () => {
     const remoteVersion = 'remote version';
     const localVersion = 'local version';
 
-    packageHandler.writePackageJson(remoteFile, {version: remoteVersion});
-    packageHandler.writePackageJson(localFile, {version: localVersion});
+    await packageHandler.writePackageJson(remoteFile, {version: remoteVersion});
+    await packageHandler.writePackageJson(localFile, {version: localVersion});
 
-    versionFetcher.copyVersion(remotePath, localPath, 'kaki.json', x => Object.assign(x, {abc: 123}));
-    expect(packageHandler.readPackageJson(remoteFile)).to.eql(packageHandler.readPackageJson(localFile));
-    expect(packageHandler.readPackageJson(localFile).version).to.eql(remoteVersion);
-    expect(packageHandler.readPackageJson(localFile).abc).to.eql(123);
+    await versionFetcher.copyVersion(remotePath, localPath, 'kaki.json', x => Object.assign(x, {abc: 123}));
+
+    const localPkg = await packageHandler.readPackageJson(localFile);
+    const remotePkg = await packageHandler.readPackageJson(remoteFile);
+
+    expect(remotePkg).to.eql(localPkg);
+    expect(localPkg.version).to.eql(remoteVersion);
+    expect(localPkg.abc).to.eql(123);
   });
 
-  it('should ignore exceptions when copying versions', () => {
-    versionFetcher.copyVersion('/a', '/b', 'kaki.json');
+  it('should ignore exceptions when copying versions', async () => {
+    await versionFetcher.copyVersion('/a', '/b', 'kaki.json');
   });
 
   it('should propagate errors in fetch', () => {

--- a/test/version-fetcher.spec.js
+++ b/test/version-fetcher.spec.js
@@ -9,15 +9,15 @@ use(chaiAsPromised);
 
 describe('version-fetcher', () => {
   it('should retrieve the version from npm and pack it', async () => {
-    const dirName = versionFetcher.fetch('wnpm-ci', '6.2.0');
+    const dirName = await versionFetcher.fetch('wnpm-ci', '6.2.0');
     const pkg = await packageHandler.readPackageJson(path.join(dirName, 'package.json'));
     expect(pkg.name).to.equal('wnpm-ci');
     expect(pkg.version).to.equal('6.2.0');
   });
 
   it('should pack current package', async () => {
-    const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
-    const dirName = versionFetcher.cloneAndPack(cwd);
+    const cwd = await versionFetcher.fetch('wnpm-ci', '6.2.0');
+    const dirName = await versionFetcher.cloneAndPack(cwd);
     const pkg = await packageHandler.readPackageJson(path.join(dirName, 'package.json'));
     expect(pkg.name).to.equal('wnpm-ci');
     expect(pkg.version).to.equal('6.2.0');
@@ -49,11 +49,9 @@ describe('version-fetcher', () => {
     await versionFetcher.copyVersion('/a', '/b', 'kaki.json');
   });
 
-  it('should propagate errors in fetch', () => {
-    expect(() => versionFetcher.fetch('wnpm-ci', '0.0.1')).to.throw();
-  });
+  it('should propagate errors in fetch', () =>
+    expect(versionFetcher.fetch('wnpm-ci', '0.0.1')).to.be.rejected);
 
-  it('should propagate errors in cloneAndPack', () => {
-    expect(() => versionFetcher.cloneAndPack('/no-such-dir')).to.throw();
-  });
+  it('should propagate errors in cloneAndPack', () =>
+    expect(versionFetcher.cloneAndPack('/no-such-dir')).to.be.rejected);
 });

--- a/test/wnpm-release.spec.js
+++ b/test/wnpm-release.spec.js
@@ -9,7 +9,7 @@ const packageHandler = require('../lib/package-handler');
 describe('wnpm-release', () => {
   it('should not release a new version if same tarball is published', async () => {
     const latest = execSync('npm view . dist-tags.latest').toString().trim();
-    const cwd = versionFetcher.fetch('wnpm-ci', latest);
+    const cwd = await versionFetcher.fetch('wnpm-ci', latest);
     await prepareForRelease({cwd});
 
     const pkg = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
@@ -18,7 +18,7 @@ describe('wnpm-release', () => {
   });
 
   it('should bump patch by default', async () => {
-    const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
+    const cwd = await versionFetcher.fetch('wnpm-ci', '6.2.0');
     await prepareForRelease({cwd});
 
     const pkg = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
@@ -28,7 +28,7 @@ describe('wnpm-release', () => {
   });
 
   it('should bump minor', async () => {
-    const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
+    const cwd = await versionFetcher.fetch('wnpm-ci', '6.2.0');
     await prepareForRelease({cwd, shouldBumpMinor: true});
 
     const pkg = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
@@ -38,7 +38,7 @@ describe('wnpm-release', () => {
   });
 
   it('should not touch version if it was modifier manually', async () => {
-    const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
+    const cwd = await versionFetcher.fetch('wnpm-ci', '6.2.0');
     execSync(`npm version --no-git-tag-version 6.5.0`, {cwd});
     await prepareForRelease({cwd, shouldBumpMinor: true});
 
@@ -48,7 +48,7 @@ describe('wnpm-release', () => {
   });
 
   it('should support initial publish of new package', async () => {
-    const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
+    const cwd = await versionFetcher.fetch('wnpm-ci', '6.2.0');
     const json = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     await packageHandler.writePackageJson(path.join(cwd, 'package.json'), {...json, name: 'wnpm-kukuriku'});
     await prepareForRelease({cwd, shouldBumpMinor: true});
@@ -59,9 +59,9 @@ describe('wnpm-release', () => {
   });
 
   it('should bump version if comparing to published version fails', async () => {
-    const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
+    const cwd = await versionFetcher.fetch('wnpm-ci', '6.2.0');
     const originalFetch = versionFetcher.fetch;
-    versionFetcher.fetch = () => { throw new Error("Failed!")};
+    versionFetcher.fetch = () => Promise.reject(new Error("Failed!"));
     await prepareForRelease({cwd});
     versionFetcher.fetch = originalFetch;
 
@@ -74,7 +74,7 @@ describe('wnpm-release', () => {
 
 describe('wnpm-release cli', () => {
   it('should bump patch by default', async () => {
-    const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
+    const cwd = await versionFetcher.fetch('wnpm-ci', '6.2.0');
     execSync(path.resolve(__dirname, '../scripts/wnpm-release.js'), {cwd});
 
     const pkg = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
@@ -84,7 +84,7 @@ describe('wnpm-release cli', () => {
   });
 
   it('should bump minor', async () => {
-    const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
+    const cwd = await versionFetcher.fetch('wnpm-ci', '6.2.0');
     execSync(path.resolve(__dirname, '../scripts/wnpm-release.js --bump-minor'), {cwd});
     const pkg = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);

--- a/test/wnpm-release.spec.js
+++ b/test/wnpm-release.spec.js
@@ -12,7 +12,7 @@ describe('wnpm-release', () => {
     const cwd = versionFetcher.fetch('wnpm-ci', latest);
     await prepareForRelease({cwd});
 
-    const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
+    const pkg = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(true);
     expect(pkg.version).to.equal(latest);
   });
@@ -21,7 +21,7 @@ describe('wnpm-release', () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
     await prepareForRelease({cwd});
 
-    const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
+    const pkg = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);
     expect(pkg.version).to.not.equal('6.2.0');
     expect(pkg.version).to.contain('6.2.');
@@ -31,7 +31,7 @@ describe('wnpm-release', () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
     await prepareForRelease({cwd, shouldBumpMinor: true});
 
-    const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
+    const pkg = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);
     expect(pkg.version).to.not.equal('6.2.0');
     expect(pkg.version).to.contain('6.3.');
@@ -42,18 +42,18 @@ describe('wnpm-release', () => {
     execSync(`npm version --no-git-tag-version 6.5.0`, {cwd});
     await prepareForRelease({cwd, shouldBumpMinor: true});
 
-    const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
+    const pkg = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);
     expect(pkg.version).to.equal('6.5.0');
   });
 
   it('should support initial publish of new package', async () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
-    const json = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
-    packageHandler.writePackageJson(path.join(cwd, 'package.json'), {...json, name: 'wnpm-kukuriku'});
+    const json = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
+    await packageHandler.writePackageJson(path.join(cwd, 'package.json'), {...json, name: 'wnpm-kukuriku'});
     await prepareForRelease({cwd, shouldBumpMinor: true});
 
-    const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
+    const pkg = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);
     expect(pkg.version).to.equal('6.2.0');
   });
@@ -65,7 +65,7 @@ describe('wnpm-release', () => {
     await prepareForRelease({cwd});
     versionFetcher.fetch = originalFetch;
 
-    const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
+    const pkg = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);
     expect(pkg.version).to.not.equal('6.2.0');
     expect(pkg.version).to.contain('6.2.');
@@ -73,20 +73,20 @@ describe('wnpm-release', () => {
 });
 
 describe('wnpm-release cli', () => {
-  it('should bump patch by default', () => {
+  it('should bump patch by default', async () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
     execSync(path.resolve(__dirname, '../scripts/wnpm-release.js'), {cwd});
 
-    const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
+    const pkg = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);
     expect(pkg.version).to.not.equal('6.2.0');
     expect(pkg.version).to.contain('6.2.');
   });
 
-  it('should bump minor', () => {
+  it('should bump minor', async () => {
     const cwd = versionFetcher.fetch('wnpm-ci', '6.2.0');
     execSync(path.resolve(__dirname, '../scripts/wnpm-release.js --bump-minor'), {cwd});
-    const pkg = packageHandler.readPackageJson(path.join(cwd, 'package.json'));
+    const pkg = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
     expect(pkg.private).to.equal(undefined);
     expect(pkg.version).to.not.equal('6.2.0');
     expect(pkg.version).to.contain('6.3.');

--- a/test/write-git-head.spec.js
+++ b/test/write-git-head.spec.js
@@ -23,40 +23,40 @@ describe('write-git-head', () => {
     process.env.BUILD_VCS_NUMBER = INITIAL_BUILD_VCS_NUMBER;
   });
 
-  it('should create .git dir and write a git HEAD if BUILD_VCS_NUMBER exists', () => {
+  it('should create .git dir and write a git HEAD if BUILD_VCS_NUMBER exists', async () => {
     const headFile = path.join(dirName, '.git/HEAD');
-    writeGitHead(dirName);
+    await writeGitHead(dirName);
 
     expect(fs.existsSync(headFile));
     expect(fs.readFileSync(headFile, 'utf-8')).to.be.equal(commitSha);
   });
 
-  it('should write a git HEAD to .git if BUILD_VCS_NUMBER exists', () => {
+  it('should write a git HEAD to .git if BUILD_VCS_NUMBER exists', async () => {
     const gitDirname = path.join(dirName, '.git');
     const headFile = path.join(gitDirname, 'HEAD');
     mkdirp.sync(gitDirname)
-    writeGitHead(dirName);
+    await writeGitHead(dirName);
 
     expect(fs.existsSync(headFile));
     expect(fs.readFileSync(headFile, 'utf-8')).to.be.equal(commitSha);
   });
 
-  it('should not write a git HEAD if .git/HEAD exists', () => {
+  it('should not write a git HEAD if .git/HEAD exists', async () => {
     const gitDirname = path.join(dirName, '.git');
     const headFile = path.join(gitDirname, 'HEAD');
     const existedSha = '1bfbkw47c3feaae5u3s2100oi2575fee1ba01f8w'
     mkdirp.sync(gitDirname)
     fs.writeFileSync(headFile, existedSha, {encoding: 'utf-8'});
-    writeGitHead(dirName);
+    await writeGitHead(dirName);
 
     expect(fs.existsSync(headFile));
     expect(fs.readFileSync(headFile, 'utf-8')).to.be.equal(existedSha);
   });
 
-  it('should not write a git HEAD if BUILD_VCS_NUMBER doesn\'t exist', () => {
+  it('should not write a git HEAD if BUILD_VCS_NUMBER doesn\'t exist', async () => {
     const headFile = path.join(dirName, '.git/HEAD');
     delete process.env.BUILD_VCS_NUMBER;
-    writeGitHead(dirName);
+    await writeGitHead(dirName);
 
     expect(fs.existsSync(headFile) === false);
   });


### PR DESCRIPTION
## Description
Many IO operations were synchronous, meaning that work could not be parallelized. This PR changes many shell operations, network fetches and fs read and writes to be async.

## Changes
1. Added `fs-extra` as dep, in order to use promisable fs operations.
2. Added `chai-as-promised` for promise rejection tests
3. Every `fooSync` operation was changed into an async version of itself (e.g. `readFileSync` into `await readFile`)
4. Recursively changed all related functions into async functions
5. Updated tests to use `async \ await`