### PR TITLE
Support Using Custom Registries on Release

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "chai": "^4.0.0",
     "chai-as-promised": "^7.1.1",
     "mocha": "^5.0.0",
-    "mocha-env-reporter": "^4.0.0"
+    "mocha-env-reporter": "^4.0.0",
+    "verdaccio": "^4.3.4",
+    "wait-port": "^0.2.6"
   },
   "dependencies": {
     "execa": "^2.0.3",

--- a/test/drivers/registry.js
+++ b/test/drivers/registry.js
@@ -1,0 +1,66 @@
+const fs = require('fs-extra');
+const path = require('path');
+const execa = require('execa');
+const waitPort = require('wait-port');
+const tmp = require('tmp');
+
+module.exports.aRegistryDriver = ({ port = 4873 } = {}) => {
+  let verdaccioDir;
+  let verdaccioProcess;
+
+  const start = async () => {
+    const verdaccioExecPath = path.join(__dirname, '..', '..', 'node_modules', '.bin', 'verdaccio');
+    const verdaccioConfig = 'verdaccio.yaml';
+
+    verdaccioDir = tmp.dirSync({ unsafeCleanup: true });
+    await fs.copyFile(path.join(__dirname, verdaccioConfig), path.join(verdaccioDir.name, verdaccioConfig));
+
+    verdaccioProcess = execa(`${verdaccioExecPath} -l localhost:${port} -c ${path.join(verdaccioDir.name, verdaccioConfig)}`, { cwd: verdaccioDir.name, shell: true });
+    await waitPort({ port });
+  };
+
+  const stop = () => {
+    verdaccioProcess && verdaccioProcess.kill();
+    verdaccioDir && verdaccioDir.removeCallback();
+  };
+
+  const getRegistryUrl = () => {
+    return `http://localhost:${port}`;
+  };
+
+  const putPackageInRegistry = async ({ packageName, version }) => {
+    const dir = tmp.dirSync({ unsafeCleanup: true });
+    const packageJson = {
+      name: packageName,
+      version,
+      public: true
+    }
+    const npmRc = `//localhost:${port}/:_authToken=cm95IHNvbW1lciB3YXMgaGVyZQ==\n`;
+
+    await Promise.all([
+      fs.writeFile(path.join(dir.name, 'package.json'), JSON.stringify(packageJson)),
+      fs.writeFile(path.join(dir.name, '.npmrc'), npmRc)
+    ]);
+
+    await execa(`npm publish --registry=http://localhost:${port}`, { cwd: dir.name, shell: true, stdio: 'inherit' });
+
+    dir.removeCallback();
+  };
+
+  const fetchPackage = async ({ packageName, version }) => {
+    const dir = tmp.dirSync({ unsafeCleanup: true });
+
+    await execa(`npm pack --registry=http://localhost:${port} ${packageName}@${version}`, { cwd: dir.name, shell: true });
+    await execa('tar -xf *.tgz', { cwd: dir.name, shell: true });
+
+    return path.join(dir.name, 'package');
+  }
+
+  return {
+    start,
+    stop,
+    getRegistryUrl,
+    putPackageInRegistry,
+    fetchPackage
+  }
+}

--- a/test/drivers/verdaccio.yaml
+++ b/test/drivers/verdaccio.yaml
@@ -1,0 +1,10 @@
+storage: ./storage-internal
+
+auth:
+  htpasswd:
+    file: ./htpasswd-internal
+
+packages:
+  '**':
+    access: $all
+    publish: $all


### PR DESCRIPTION
## Description
`prepareForRelease` programmatic API now accepts an optional `registries` array, which makes it use those registries when calculating next version.

This is required by `wix-fed-scripts` in order to test version bumping logic.

Example:
```ts
prepareForRelease({ registries: ['http://localhost:4873'] });
```

The feature is fully tested (e2e) by using `verdaccio`.