### PR TITLE
support comparing to another published version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#490B68",
+        "titleBar.activeBackground": "#661092",
+        "titleBar.activeForeground": "#FEFCFF"
+    }
+}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const execa = require('execa');
-const {compare} = require('./lib/version-comparator');
+const {compare, compareVersions} = require('./lib/version-comparator');
 const packageHandler = require('./lib/package-handler');
 const versionCalculations = require('./lib/version-calculations');
 const writeGitHead = require('./lib/write-git-head');
@@ -67,10 +67,22 @@ async function isSameAsPublished(registryVersions, options) {
   const localPackageVersion = (await packageHandler.readPackageJson(path.join(options.cwd, 'package.json'))).version;
   const currentPublishedVersion = versionCalculations.calculateCurrentPublished(localPackageVersion, registryVersions, options);
 
-  if (currentPublishedVersion && await compare(options.cwd, currentPublishedVersion)) {
-    return currentPublishedVersion;
-  } else {
+  if (!currentPublishedVersion) {
     return false;
+  }
+
+  let isSame = false;
+
+  if (options.versionToCompare) {
+    isSame = await compareVersions(options.cwd, options.versionToCompare, currentPublishedVersion)
+  } else {
+    isSame = await compare(options.cwd, currentPublishedVersion)
+  }
+
+  if (isSame) {
+    return currentPublishedVersion
+  } else {
+    return false
   }
 }
 

--- a/lib/version-comparator.js
+++ b/lib/version-comparator.js
@@ -9,5 +9,11 @@ module.exports = {
     const {name} = await packageHandler.readPackageJson(path.join(cwd, 'package.json'))
     const remoteVersionPath = await versionFetcher.fetch(name, version, cwd);
     return await compareDirectories(remoteVersionPath, currVersionPath);
+  },
+  compareVersions: async (cwd, a, b) => {
+    const {name} = await packageHandler.readPackageJson(path.join(cwd, 'package.json'))
+    const aVersionPath = await versionFetcher.fetch(name, a, cwd);
+    const bVersionPath = await versionFetcher.fetch(name, b, cwd);
+    return await compareDirectories(aVersionPath, bVersionPath);
   }
 };

--- a/test/wnpm-release.spec.js
+++ b/test/wnpm-release.spec.js
@@ -72,6 +72,25 @@ describe('wnpm-release', () => {
     expect(pkg.version).to.contain('6.2.');
   });
 
+  describe('with comparing to a published version (with http url)', () => {
+    it('should not bump a version when comparing lastest to the matching version', async () => {
+      const cwd = await versionFetcher.fetch('tmp.xsb6m4j2', '1.0.0');
+      await prepareForRelease({ cwd, versionToCompare: 'https://registry.npmjs.org/tmp.xsb6m4j2/-/tmp.xsb6m4j2-1.0.0-same.tgz'});
+  
+      const pkg = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
+      expect(pkg.private).to.equal(true);
+    })
+
+    it('should bump a version when comparing lastest to a non matching version', async () => {
+      const cwd = await versionFetcher.fetch('tmp.xsb6m4j2', '1.0.0');
+      await prepareForRelease({ cwd, versionToCompare: 'https://registry.npmjs.org/tmp.xsb6m4j2/-/tmp.xsb6m4j2-1.0.0-not-same.tgz'});
+  
+      const pkg = await packageHandler.readPackageJson(path.join(cwd, 'package.json'));
+      expect(pkg.private).to.equal(undefined);
+      expect(pkg.version).to.equal('1.0.1')
+    })
+  })
+
   describe('with custom registry', () => {
     let registry = aRegistryDriver();
 


### PR DESCRIPTION
In order to support republish cases (when skipping a build) we want to compare against the version that is about to be republished instead of the current working directory.